### PR TITLE
[global] Released Version 0.2.0

### DIFF
--- a/jvmbrotli/pom.xml
+++ b/jvmbrotli/pom.xml
@@ -7,13 +7,14 @@
     <parent>
         <groupId>com.nixxcode.jvmbrotli</groupId>
         <artifactId>jvmbrotli-parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>jvmbrotli</artifactId>
     <packaging>jar</packaging>
 
     <profiles>
+
         <profile>
             <id>win32-x86-amd64</id>
             <activation>
@@ -26,7 +27,7 @@
                 <dependency>
                     <groupId>com.nixxcode.jvmbrotli</groupId>
                     <artifactId>jvmbrotli-win32-x86-amd64</artifactId>
-                    <version>0.2.0-SNAPSHOT</version>
+                    <version>0.2.0</version>
                 </dependency>
             </dependencies>
         </profile>
@@ -43,7 +44,7 @@
                 <dependency>
                     <groupId>com.nixxcode.jvmbrotli</groupId>
                     <artifactId>jvmbrotli-win32-x86</artifactId>
-                    <version>0.2.0-SNAPSHOT</version>
+                    <version>0.2.0</version>
                 </dependency>
             </dependencies>
         </profile>
@@ -59,7 +60,7 @@
                 <dependency>
                     <groupId>com.nixxcode.jvmbrotli</groupId>
                     <artifactId>jvmbrotli-darwin-x86-amd64</artifactId>
-                    <version>0.2.0-SNAPSHOT</version>
+                    <version>0.2.0</version>
                 </dependency>
             </dependencies>
         </profile>
@@ -76,7 +77,7 @@
                 <dependency>
                     <groupId>com.nixxcode.jvmbrotli</groupId>
                     <artifactId>jvmbrotli-linux-x86-amd64</artifactId>
-                    <version>0.2.0-SNAPSHOT</version>
+                    <version>0.2.0</version>
                 </dependency>
             </dependencies>
         </profile>
@@ -93,9 +94,47 @@
                 <dependency>
                     <groupId>com.nixxcode.jvmbrotli</groupId>
                     <artifactId>jvmbrotli-linux-arm32-vfp-hflt</artifactId>
-                    <version>0.2.0-SNAPSHOT</version>
+                    <version>0.2.0</version>
                 </dependency>
             </dependencies>
+        </profile>
+
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                </plugins>
+            </build>
+
         </profile>
 
     </profiles>

--- a/natives/darwin-x86-amd64/pom.xml
+++ b/natives/darwin-x86-amd64/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.nixxcode.jvmbrotli</groupId>
         <artifactId>jvmbrotli-natives</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>jvmbrotli-darwin-x86-amd64</artifactId>

--- a/natives/linux-arm32-vfp-hflt/pom.xml
+++ b/natives/linux-arm32-vfp-hflt/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.nixxcode.jvmbrotli</groupId>
         <artifactId>jvmbrotli-natives</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>jvmbrotli-linux-arm32-vfp-hflt</artifactId>

--- a/natives/linux-x86-amd64/pom.xml
+++ b/natives/linux-x86-amd64/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.nixxcode.jvmbrotli</groupId>
         <artifactId>jvmbrotli-natives</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>jvmbrotli-linux-x86-amd64</artifactId>

--- a/natives/pom.xml
+++ b/natives/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.nixxcode.jvmbrotli</groupId>
         <artifactId>jvmbrotli-parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>jvmbrotli-natives</artifactId>

--- a/natives/win32-x86-amd64/pom.xml
+++ b/natives/win32-x86-amd64/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.nixxcode.jvmbrotli</groupId>
         <artifactId>jvmbrotli-natives</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>jvmbrotli-win32-x86-amd64</artifactId>

--- a/natives/win32-x86/pom.xml
+++ b/natives/win32-x86/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.nixxcode.jvmbrotli</groupId>
         <artifactId>jvmbrotli-natives</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>jvmbrotli-win32-x86</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.nixxcode.jvmbrotli</groupId>
     <artifactId>jvmbrotli-parent</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.2.0</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -79,7 +79,7 @@
                     <serverId>ossrh</serverId>
                     <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                     <autoReleaseAfterClose>false</autoReleaseAfterClose>
-                    <skipRemoteStaging>true</skipRemoteStaging>
+                    <skipRemoteStaging>false</skipRemoteStaging>
                 </configuration>
             </plugin>
 
@@ -141,34 +141,6 @@
             <id>release</id>
             <build>
                 <plugins>
-
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>3.1.0</version>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar-no-fork</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.1.0</version>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
 
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Also moved javadoc and jar maven plugins to jvmbrotli submodule, because it was errantly generating "source" jars for the native libraries